### PR TITLE
fix: update sync script and build configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@him0/ai-docs-sync",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "Sync AI documentation rules across GitHub Copilot, Cline, Cursor, and other AI tools.",
   "author": "him0",
@@ -34,10 +34,10 @@
   },
   "scripts": {
     "dev": "bun run src/cli.ts",
-    "build": "bun build src/cli.ts --target=node --outfile=dist/cli.js && bun run build:types && cp -r src/templates dist/ && chmod +x ./dist/cli.js",
+    "build": "bun build src/cli.ts --target=node --outfile=dist/cli.js --header='#!/usr/bin/env node' && bun run build:types && cp -r src/templates dist/ && chmod +x ./dist/cli.js",
     "build:types": "tsc --emitDeclarationOnly",
     "init": "bun run src/cli.ts init",
-    "sync": "bun run src/cli.ts sync",
+    "sync": "bun run src/cli.ts",
     "plan": "bun run src/cli.ts plan",
     "prepublishOnly": "bun run build",
     "test": "bun test",


### PR DESCRIPTION
## Summary
- Fix sync script to run without 'sync' argument (matches CLI behavior)
- Add explicit shebang header to build process for proper npm execution  
- Bump version to 0.3.1

## Changes
1. **Sync script fix**: Changed `"sync": "bun run src/cli.ts sync"` to `"sync": "bun run src/cli.ts"` to match the CLI's default behavior where sync runs without arguments
2. **Build configuration**: Added `--header='#\!/usr/bin/env node'` to the build command to ensure proper shebang in the output file for npm execution
3. **Version bump**: Updated to 0.3.1 for the fixes

## Test plan
- [x] Verify `bun run sync` works correctly
- [x] Verify build generates proper executable with shebang
- [ ] Test `npx @him0/ai-docs-sync` after publishing

🤖 Generated with [Claude Code](https://claude.ai/code)